### PR TITLE
FIX map or array type conversion bug.

### DIFF
--- a/lib/embulk/input/presto/explain_parser.rb
+++ b/lib/embulk/input/presto/explain_parser.rb
@@ -6,7 +6,7 @@ module Embulk
           explain_text = explain_result.flatten.last.lines.first
           column_name_raw, column_type_raw = explain_text.split(' => ')
           names = column_name_raw.split('[').last.split(']').first.split(',').map{ |name| name.strip }
-          types = column_type_raw.split('[').last.split(']').first.gsub(/\(.+?, .+?\)/, "").split(',').map{ |info| info.split(':').last }
+          types = column_type_raw.split('[').last.split(']').first.gsub(/\(.+?\)/, "").split(',').map{ |info| info.split(':').last }
           names.zip(types)
         end
       end

--- a/lib/embulk/input/presto/explain_parser.rb
+++ b/lib/embulk/input/presto/explain_parser.rb
@@ -6,7 +6,7 @@ module Embulk
           explain_text = explain_result.flatten.last.lines.first
           column_name_raw, column_type_raw = explain_text.split(' => ')
           names = column_name_raw.split('[').last.split(']').first.split(',').map{ |name| name.strip }
-          types = column_type_raw.split('[').last.split(']').first.split(',').map{ |info| info.split(':').last }
+          types = column_type_raw.split('[').last.split(']').first.gsub(/\(.+?, .+?\)/, "").split(',').map{ |info| info.split(':').last }
           names.zip(types)
         end
       end


### PR DESCRIPTION
I fixed issue #3.

Remove `(.+?, .+?)` from  a `explain` query result like `data:map(varchar, varchar)` .